### PR TITLE
fix(web): prefer opaque surface alpha mode to avoid black canvas

### DIFF
--- a/web/src/gpu.rs
+++ b/web/src/gpu.rs
@@ -120,13 +120,25 @@ impl GpuState {
                 .copied()
                 .unwrap_or(caps.formats[0]);
 
+            // Prefer an opaque surface. On some browsers `caps.alpha_modes[0]` is
+            // PreMultiplied/PostMultiplied, so the compositor blends the surface over the page
+            // and the canvas renders black even though the scene draws correctly. Opaque removes
+            // the compositor alpha path; fall back to the first advertised mode if unsupported.
+            let alpha_mode = if caps
+                .alpha_modes
+                .contains(&wgpu::CompositeAlphaMode::Opaque)
+            {
+                wgpu::CompositeAlphaMode::Opaque
+            } else {
+                caps.alpha_modes[0]
+            };
             let surface_config = wgpu::SurfaceConfiguration {
                 usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
                 format,
                 width,
                 height,
                 present_mode: wgpu::PresentMode::AutoVsync,
-                alpha_mode: caps.alpha_modes[0],
+                alpha_mode,
                 view_formats: vec![],
                 desired_maximum_frame_latency: 2,
             };


### PR DESCRIPTION
## Problem

When embedding the web viewer (patinae-web WASM) in a page, the canvas can render **fully black** even though the scene draws correctly (structure loads, orient runs, render_frame presents).

Root cause: surface.get_capabilities(&adapter).alpha_modes[0] is not guaranteed to be Opaque. On some browsers/adapters the first advertised mode is PreMultiplied/PostMultiplied, so the browser compositor blends the WebGPU surface over the page background — and with nothing behind it the canvas composites to black.

## Fix

Prefer CompositeAlphaMode::Opaque when the adapter advertises it, falling back to the first advertised mode otherwise. This removes the compositor alpha path for the common opaque-viewer case and fixes the black-canvas embedding scenario, while staying safe on adapters that do not support Opaque.

One-line behavioral change in web/src/gpu.rs surface configuration; compiles clean on wasm32-unknown-unknown (cargo check -p patinae-web).

Thanks for Patinae — great project.