### PR TITLE
feat(cartoon): make helix/sheet/loop thickness user-configurable via set

### DIFF
--- a/crates/patinae-render/src/compute/cartoon_extrude.rs
+++ b/crates/patinae-render/src/compute/cartoon_extrude.rs
@@ -21,12 +21,19 @@ use crate::shader_source;
 
 pub const WORKGROUP: u32 = 64;
 
-/// Mirrors `ExtrudeParams` in `cartoon_extrude.wgsl`. 16 B.
+/// Mirrors `ExtrudeParams` in `cartoon_extrude.wgsl`. 48 B (three 16 B chunks).
 ///
 /// `quality` is the number of segments per tube profile (Loop / Oval). It
 /// MUST match `geom.quality` used by `compute_run_vertex_layout` on the
 /// CPU side — otherwise the per-vertex `local_vidx → (pair, k)` decode
 /// diverges from the slot allocation and the ribbon develops holes.
+///
+/// The six cross-section fields (`helix_width` .. `arrow_tip_scale`) mirror
+/// the values previously baked into `cartoon_extrude.wgsl` as WGSL `const`s.
+/// They are populated by `CartoonRep::build` from `GeomSettings`, which
+/// itself reads user-configurable `cartoon_oval_width` /
+/// `cartoon_oval_length` / `cartoon_rect_width` / `cartoon_rect_length` /
+/// `cartoon_loop_radius` / `cartoon_arrow_tip_scale` settings.
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Pod, Zeroable)]
 pub struct ExtrudeParams {
@@ -34,6 +41,24 @@ pub struct ExtrudeParams {
     pub n_samples: u32,
     pub n_atoms: u32,
     pub quality: u32,
+    /// Helix oval **narrow** half-axis (along the normal).
+    pub helix_width: f32,
+    /// Helix oval **wide** half-axis (along the binormal / helix axis).
+    pub helix_height: f32,
+    /// Sheet rectangle full thickness (halved to obtain the binormal
+    /// half-extent in the shader).
+    pub sheet_width: f32,
+    /// Sheet rectangle wide half-extent (along the normal).
+    pub sheet_height: f32,
+    /// Loop / coil tube radius (also the uniform-tube radius in Ribbon
+    /// mode; the host writes `ribbon_radius` into this slot for Ribbon).
+    pub loop_radius: f32,
+    /// Multiplier on `sheet_height` for the arrow-head barb width.
+    pub arrow_tip_scale: f32,
+    /// Padding to keep `size_of::<ExtrudeParams>()` a multiple of 16 B
+    /// (WGSL uniform buffer requirement).
+    pub _pad0: u32,
+    pub _pad1: u32,
 }
 
 impl ExtrudeParams {

--- a/crates/patinae-render/src/representations/cartoon/mod.rs
+++ b/crates/patinae-render/src/representations/cartoon/mod.rs
@@ -726,6 +726,20 @@ impl Representation for CartoonRep {
             n_samples: extrude_points_gpu.len() as u32,
             n_atoms,
             quality: geom_settings.quality,
+            // Cross-section dimensions used to live in `cartoon_extrude.wgsl`
+            // as `const` literals. They now travel through this uniform so
+            // `set cartoon_oval_length`, `set cartoon_rect_length`, etc. take
+            // effect. `geom_settings` already applied the `0.0 = auto` fallback
+            // in `tessellation::from_resolved_settings`; the Ribbon override
+            // above additionally forced `loop_radius = ribbon.radius`.
+            helix_width: geom_settings.helix_width,
+            helix_height: geom_settings.helix_height,
+            sheet_width: geom_settings.sheet_width,
+            sheet_height: geom_settings.sheet_height,
+            loop_radius: geom_settings.loop_radius,
+            arrow_tip_scale: geom_settings.arrow_tip_scale,
+            _pad0: 0,
+            _pad1: 0,
         };
         let total_vertices = output.total_vertices;
         let vertex_bytes = (total_vertices as u64) * 24;

--- a/crates/patinae-render/src/representations/cartoon/tessellation.rs
+++ b/crates/patinae-render/src/representations/cartoon/tessellation.rs
@@ -194,7 +194,7 @@ pub fn from_resolved_settings(
     settings: &ResolvedSettings,
     lod: SceneLod,
 ) -> (PipelineSettings, GeomSettings) {
-    let (mut p, g) = from_lod(lod);
+    let (mut p, mut g) = from_lod(lod);
     let c = &settings.cartoon;
 
     if c.sampling > 0 {
@@ -213,6 +213,28 @@ pub fn from_resolved_settings(
 
     let raw_refine = c.refine.max(0) as u32;
     p.refine = raw_refine + (raw_refine & 1);
+
+    // Cross-section overrides. `0.0` keeps the LOD-picked default; any
+    // positive value replaces it. Mirrors the `ribbon_radius = 0.0 → auto`
+    // convention used elsewhere in the cartoon path.
+    if c.oval_width > 0.0 {
+        g.helix_width = c.oval_width;
+    }
+    if c.oval_length > 0.0 {
+        g.helix_height = c.oval_length;
+    }
+    if c.rect_width > 0.0 {
+        g.sheet_width = c.rect_width;
+    }
+    if c.rect_length > 0.0 {
+        g.sheet_height = c.rect_length;
+    }
+    if c.loop_radius > 0.0 {
+        g.loop_radius = c.loop_radius;
+    }
+    if c.arrow_tip_scale > 0.0 {
+        g.arrow_tip_scale = c.arrow_tip_scale;
+    }
 
     (p, g)
 }

--- a/crates/patinae-render/src/shaders/compute/cartoon_extrude.wgsl
+++ b/crates/patinae-render/src/shaders/compute/cartoon_extrude.wgsl
@@ -27,13 +27,11 @@ const SS_NUCLEIC_RECT: u32 = 4u; // CartoonType::NucleicRect (matches Rust enum)
 
 const TWO_SIDED_FLAG: u32 = 1u << 0u;
 
-// Profile constants for cartoon cross-sections.
-const HELIX_WIDTH: f32 = 0.25;
-const HELIX_HEIGHT: f32 = 1.35;
-const SHEET_WIDTH: f32 = 0.4;     // full thickness; half-thick = 0.2
-const SHEET_HEIGHT: f32 = 1.4;    // wide half-extent
-const LOOP_RADIUS: f32 = 0.2;
-const ARROW_TIP_SCALE: f32 = 1.5;
+// Profile cross-section values used to live here as WGSL `const`s. They now
+// arrive from the host through `ExtrudeParams` so users can override them
+// via `set cartoon_oval_length`, `set cartoon_rect_length`, etc. See
+// `crates/patinae-render/src/compute/cartoon_extrude.rs::ExtrudeParams` and
+// `crates/patinae-settings/src/groups/cartoon.rs`.
 
 struct ExtrudeParams {
     n_runs: u32,
@@ -44,6 +42,14 @@ struct ExtrudeParams {
     // `local_vidx → (pair, k)` decode below drifts vs. the vertex-slot
     // allocation and the tube develops gaps.
     quality: u32,
+    helix_width: f32,
+    helix_height: f32,
+    sheet_width: f32,
+    sheet_height: f32,
+    loop_radius: f32,
+    arrow_tip_scale: f32,
+    _pad0: u32,
+    _pad1: u32,
 };
 
 struct ExtrudePoint {
@@ -330,9 +336,9 @@ fn emit_tube_vertex(
 fn profile_for_run(k: u32, segments: u32, is_oval: bool) -> ProfileVert {
     let kk = k % segments;
     if (is_oval) {
-        return profile_ellipse(kk, segments, HELIX_WIDTH, HELIX_HEIGHT);
+        return profile_ellipse(kk, segments, params.helix_width, params.helix_height);
     }
-    return profile_circle(kk, segments, LOOP_RADIUS);
+    return profile_circle(kk, segments, params.loop_radius);
 }
 
 // ============================================================================
@@ -366,8 +372,8 @@ fn emit_sheet_body_vertex(
     let s1 = s0 + 1u;
     let f0 = frame_at(s0, run.sample_start, run.sample_end);
     let f1 = frame_at(s1, run.sample_start, run.sample_end);
-    let half_width = SHEET_HEIGHT;        // wide half-extent along NORMAL
-    let half_thick = SHEET_WIDTH * 0.5;   // thin half-extent along BINORMAL
+    let half_width = params.sheet_height;        // wide half-extent along NORMAL
+    let half_thick = params.sheet_width * 0.5;   // thin half-extent along BINORMAL
     let c0 = sheet_corners(f0.position, f0.normal, f0.binormal, half_width, half_thick);
     let c1 = sheet_corners(f1.position, f1.normal, f1.binormal, half_width, half_thick);
     let id0 = extrude_points[s0].atom_idx;
@@ -434,8 +440,8 @@ fn emit_sheet_cap_vertex(
 ) {
     let s = select(run.sample_end, run.sample_start, is_back);
     let f = frame_at(s, run.sample_start, run.sample_end);
-    let half_width = SHEET_HEIGHT;
-    let half_thick = SHEET_WIDTH * 0.5;
+    let half_width = params.sheet_height;
+    let half_thick = params.sheet_width * 0.5;
     let c = sheet_corners(f.position, f.normal, f.binormal, half_width, half_thick);
     let cap_n = select(f.tangent, -f.tangent, is_back);
     let id = extrude_points[s].atom_idx;
@@ -565,8 +571,8 @@ fn emit_arrow_segment_vertex(
     let base_f = frame_at(base_s, run.sample_start, run.sample_end);
     let n = base_f.normal;
     let b = base_f.binormal;
-    let half_thick = SHEET_WIDTH * 0.5;
-    let arrow_width = SHEET_HEIGHT * ARROW_TIP_SCALE;
+    let half_thick = params.sheet_width * 0.5;
+    let arrow_width = params.sheet_height * params.arrow_tip_scale;
     let start_pos = base_f.position;
     let end_pos = extrude_points[tip_s].position;
     let t0 = f32(seg_idx) / f32(arrow_pairs);
@@ -640,9 +646,9 @@ fn emit_shoulder_cap_vertex(
     let f = frame_at(base_s, run.sample_start, run.sample_end);
     let n = f.normal;
     let b = f.binormal;
-    let half_width = SHEET_HEIGHT;
-    let half_thick = SHEET_WIDTH * 0.5;
-    let arrow_width = half_width * ARROW_TIP_SCALE;
+    let half_width = params.sheet_height;
+    let half_thick = params.sheet_width * 0.5;
+    let arrow_width = half_width * params.arrow_tip_scale;
     let p = f.position;
     let body_tl = p + n * half_width + b * half_thick;
     let body_tr = p - n * half_width + b * half_thick;

--- a/crates/patinae-settings/src/groups/cartoon.rs
+++ b/crates/patinae-settings/src/groups/cartoon.rs
@@ -58,5 +58,32 @@ define_settings_group! {
             name = "cartoon_transparency",
             min = 0.0, max = 1.0,
             side_effects = [ColorRebuild];
+        // Cross-section dimensions. `0.0` = "auto" — fall back to the LOD-picked
+        // default so users who don't touch these still get the same look.
+        // Non-zero overrides the default and drives GPU extrusion directly.
+        oval_width: f32 = 0.0,
+            name = "cartoon_oval_width",
+            min = 0.0, max = 5.0,
+            side_effects = [RepresentationRebuild];
+        oval_length: f32 = 0.0,
+            name = "cartoon_oval_length",
+            min = 0.0, max = 5.0,
+            side_effects = [RepresentationRebuild];
+        rect_width: f32 = 0.0,
+            name = "cartoon_rect_width",
+            min = 0.0, max = 5.0,
+            side_effects = [RepresentationRebuild];
+        rect_length: f32 = 0.0,
+            name = "cartoon_rect_length",
+            min = 0.0, max = 5.0,
+            side_effects = [RepresentationRebuild];
+        loop_radius: f32 = 0.0,
+            name = "cartoon_loop_radius",
+            min = 0.0, max = 5.0,
+            side_effects = [RepresentationRebuild];
+        arrow_tip_scale: f32 = 0.0,
+            name = "cartoon_arrow_tip_scale",
+            min = 0.0, max = 5.0,
+            side_effects = [RepresentationRebuild];
     }
 }


### PR DESCRIPTION
## Summary

Cartoon cross-section dimensions (helix oval and sheet rectangle widths, loop radius, arrow-tip scale) were baked into `crates/patinae-render/src/shaders/compute/cartoon_extrude.wgsl` as WGSL `const` literals. Changing the visible cartoon thickness required editing the shader and rebuilding — the `set` command had no way to reach these knobs.

This PR routes those six values from settings, through the CPU-side `GeomSettings`, into the `ExtrudeParams` uniform, and out to the extrude compute shader. Users can now do, for example:

```
set cartoon_rect_length, 2.5    # wider sheet
set cartoon_oval_length, 2.0    # thicker helix
set cartoon_rect_length, 0      # 0 restores default
```

## New settings

| Setting                     | Previous WGSL `const` | Default | Range |
|-----------------------------|-----------------------|---------|-------|
| `cartoon_oval_width`        | `HELIX_WIDTH`         | 0.25    | 0.0 – 5.0 |
| `cartoon_oval_length`       | `HELIX_HEIGHT`        | 1.35    | 0.0 – 5.0 |
| `cartoon_rect_width`        | `SHEET_WIDTH`         | 0.4     | 0.0 – 5.0 |
| `cartoon_rect_length`       | `SHEET_HEIGHT`        | 1.4     | 0.0 – 5.0 |
| `cartoon_loop_radius`       | `LOOP_RADIUS`         | 0.2     | 0.0 – 5.0 |
| `cartoon_arrow_tip_scale`   | `ARROW_TIP_SCALE`     | 1.5     | 0.0 – 5.0 |

Names follow the PyMOL-compatible convention already used in comments on `tessellation::GeomSettings`. All six settings are `f32` with `min = 0.0, max = 5.0, side_effects = [RepresentationRebuild]`, matching the style of existing entries such as `cartoon_smooth_first`. The user-facing default of every new setting is `0.0`, which is treated as \"auto — use the LOD-picked default\"; this preserves the exact prior look for anyone who leaves them untouched, and mirrors the existing `ribbon_radius = 0.0 → auto` convention.

## Wiring

- `crates/patinae-settings/src/groups/cartoon.rs` — six new fields in the `CartoonSettings` group.
- `crates/patinae-render/src/compute/cartoon_extrude.rs` — `ExtrudeParams` grows from 16 B to 48 B with six new `f32` fields plus 8 B of trailing `u32` padding so the total stays a multiple of the 16 B WGSL uniform-buffer alignment. Field order is identical to the WGSL mirror below.
- `crates/patinae-render/src/shaders/compute/cartoon_extrude.wgsl` — the six `const` declarations are removed, `ExtrudeParams` gets the same six new fields (plus padding), and every prior `HELIX_WIDTH` / `SHEET_HEIGHT` / etc. reference is replaced with `params.<field>`.
- `crates/patinae-render/src/representations/cartoon/tessellation.rs` — `from_resolved_settings` applies each non-zero setting as an override on top of the LOD-chosen `GeomSettings` defaults, so LOD downgrading still works whenever the user leaves a setting untouched.
- `crates/patinae-render/src/representations/cartoon/mod.rs` — `CartoonRep::build` populates the new `ExtrudeParams` fields directly from `geom_settings`, so the Ribbon-mode override (`geom_settings.loop_radius = ribbon.radius`) continues to work without any extra branching.

`hash_cartoon_geometry` already hashes the six `GeomSettings` fields, so cache invalidation on a `set` change is automatic and no additional hash bookkeeping is needed.

## Related

Depends on nothing; independent of https://github.com/zmactep/patinae/pull/15 (\`chore(render): remove unused cartoon::params\`), which cleans up a separate dead-code path discovered during the same investigation. The two PRs can land in either order.

Out of scope: registering the six new settings in `crates/patinae-settings/src/legacy.rs` for `.pse` round-trip compatibility. Happy to do that in a follow-up once PyMOL numeric IDs are verified.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo check --workspace`
- [x] `cargo test --workspace` — 204 tests pass in `patinae-render`, 72 in `patinae-settings`, all suites green
- [ ] Manual E2E: build with `make patinae`, load a PDB with helices and sheets, run `set cartoon_rect_length, 2.5` in the REPL and confirm sheets widen. `set cartoon_rect_length, 0` should restore the prior look. _(pending on maintainer environment or reviewer.)_