### PR TITLE
fix(cartoon): correct nucleic acid secondary-structure decode and sheet-flatten scope

### DIFF
--- a/crates/patinae-render/src/representations/cartoon/tessellation.rs
+++ b/crates/patinae-render/src/representations/cartoon/tessellation.rs
@@ -56,6 +56,9 @@ fn ss_from_u8(v: u8) -> SecondaryStructure {
         2 => SecondaryStructure::Sheet,
         3 => SecondaryStructure::Helix310,
         4 => SecondaryStructure::HelixPi,
+        5 => SecondaryStructure::Turn,
+        6 => SecondaryStructure::Bend,
+        7 => SecondaryStructure::NucleicRibbon,
         _ => SecondaryStructure::Loop,
     }
 }
@@ -598,7 +601,13 @@ fn find_sheet_runs(gps: &[GuidePoint]) -> Vec<(usize, usize)> {
     let mut runs = Vec::new();
     let mut first: Option<usize> = None;
     for (a, gp) in gps.iter().enumerate() {
-        if gp.ss_type.is_flat_ribbon() {
+        // Beta-sheet only: `flatten_sheets` is tuned to iron out a short
+        // (3-10 residue) strand's CA zig-zag into a plane. Nucleic acid
+        // guide points are also `is_flat_ribbon()`, but running the same
+        // window-averaging over an entire 20-30+ nt strand erases the
+        // backbone's natural helical twist -- the exact signal that makes
+        // it read as a double helix instead of a flat/straight band.
+        if gp.ss_type.is_sheet() {
             if first.is_none() {
                 first = Some(a);
             }
@@ -1089,6 +1098,53 @@ mod tests {
             cartoon_type_for(SecondaryStructure::Loop, &geom),
             CartoonType::Loop
         );
+    }
+
+    #[test]
+    fn ss_from_u8_roundtrips_all_variants() {
+        let variants = [
+            SecondaryStructure::Loop,
+            SecondaryStructure::Helix,
+            SecondaryStructure::Sheet,
+            SecondaryStructure::Helix310,
+            SecondaryStructure::HelixPi,
+            SecondaryStructure::Turn,
+            SecondaryStructure::Bend,
+            SecondaryStructure::NucleicRibbon,
+        ];
+        for ss in variants {
+            assert_eq!(ss_from_u8(ss as u8), ss, "round-trip failed for {ss:?}");
+        }
+    }
+
+    #[test]
+    fn find_sheet_runs_excludes_nucleic_ribbon() {
+        // A run of NucleicRibbon guide points must not be treated as a
+        // sheet run -- flatten_sheets' window-averaging is tuned for a
+        // short beta-strand zig-zag and would iron out a nucleic strand's
+        // helical twist if applied to it.
+        let gps: Vec<GuidePoint> = (0..20)
+            .map(|i| GuidePoint {
+                position: Vec3::new(i as f32, 0.0, 0.0),
+                orientation: Vec3::new(0.0, 0.0, 1.0),
+                ss_type: SecondaryStructure::NucleicRibbon,
+                atom_idx: i,
+            })
+            .collect();
+        assert!(find_sheet_runs(&gps).is_empty());
+    }
+
+    #[test]
+    fn find_sheet_runs_still_finds_sheet() {
+        let gps: Vec<GuidePoint> = (0..5)
+            .map(|i| GuidePoint {
+                position: Vec3::new(i as f32, 0.0, 0.0),
+                orientation: Vec3::new(0.0, 0.0, 1.0),
+                ss_type: SecondaryStructure::Sheet,
+                atom_idx: i,
+            })
+            .collect();
+        assert_eq!(find_sheet_runs(&gps), vec![(0, 4)]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Double-stranded DNA/RNA cartoons render as a flat/round band instead of a proper helical ribbon shape, because of two related bugs in the same code path:

1. **`ss_from_u8()` doesn't decode `NucleicRibbon`.** `crates/patinae-render/src/representations/cartoon/tessellation.rs` packs `SecondaryStructure as u8` into `BackboneAtom.flags` on encode (nucleic residues correctly tagged `NucleicRibbon = 7`, see `backbone.rs:997`), but the decode function only handles codes 1-4:

   ```rust
   fn ss_from_u8(v: u8) -> SecondaryStructure {
       match v {
           1 => SecondaryStructure::Helix,
           2 => SecondaryStructure::Sheet,
           3 => SecondaryStructure::Helix310,
           4 => SecondaryStructure::HelixPi,
           _ => SecondaryStructure::Loop,   // 5 (Turn), 6 (Bend), 7 (NucleicRibbon) all land here
       }
   }
   ```

   Its own doc comment claims to be the full "inverse of `SecondaryStructure as u8`" -- it isn't. Every nucleic guide point gets silently reclassified as `Loop`, so `cartoon_type_for()` (`tessellation.rs:256-273`) renders DNA/RNA as a plain round tube (`CartoonType::Loop`) instead of the intended flat `CartoonType::NucleicRect` ribbon -- directly contradicting this module's own doc comment (`backbone.rs:19-20`): *"SS tag forced to `NucleicRibbon` so `cartoon_type_for` maps to `CartoonType::NucleicRect`"*.

2. **Once (1) is fixed, the sheet-flatten pass wrongly applies to nucleic acids too.** `SecondaryStructure::is_flat_ribbon()` matches `Sheet | NucleicRibbon`, and it's used in exactly one place, `find_sheet_runs()` (`tessellation.rs:601`), feeding `flatten_sheets()`: a 4-cycle (`cartoon_flat_cycles`, default 4) window-1 Laplacian smoothing pass tuned to iron out a short (3-10 residue) beta-strand's CA zig-zag into a flat plane. Run over an entire 20-36+ nt nucleic strand instead, it progressively erases the backbone's natural helical wobble (~34 A pitch / ~36 deg per bp twist) -- exactly the signal that makes a cartoon read as a double helix rather than a flat/straight band.

Both are bundled into this one PR since fixing only the first would make the visible behavior *worse* on its own (correctly-shaped-but-over-smoothed instead of a round tube) -- they need to land together to actually restore correct rendering.

## Fix

- `ss_from_u8`: complete the match arms (`5 => Turn`, `6 => Bend`, `7 => NucleicRibbon`).
- `find_sheet_runs`: check `ss_type.is_sheet()` instead of `.is_flat_ribbon()`, so only real beta-sheet runs get flattened. `is_flat_ribbon()` has no other caller; left in place as public API rather than removed, out of scope for a bugfix.

## Testing

- New unit tests: full round-trip of all 8 `SecondaryStructure` variants through `ss as u8` -> `ss_from_u8` (would have caught the original bug), plus `find_sheet_runs` behavior on a synthetic nucleic run (now empty) vs. a sheet run (unchanged).
- `cargo test -p patinae-mol -p patinae-render`: 203 passed, 0 failed (200 existing + 3 new).
- `cargo fmt --check` / `cargo clippy --no-deps`: clean.
- Manual QC: rendered an idealized canonical B-form duplex (built via this project's own `fnab`) and a real protein-DNA structure (PDB 8C58, a CpG methyltransferase with 5hmC/5mC-modified dsDNA) through the patched desktop app on real Metal/wgpu hardware -- both strands now trace a genuine helical path instead of a flat band.

No behavior change for protein cartoons (helix/sheet/loop).