### PR TITLE
fix(mol): don't split a polymer subchain on an interior HETATM residue

### DIFF
--- a/crates/patinae-mol/src/subchain.rs
+++ b/crates/patinae-mol/src/subchain.rs
@@ -570,11 +570,22 @@ impl<'a> Iterator for SubchainAtomIndexedIter<'a> {
 /// Atoms in the same raw run share their chain identifier, their hetatm flag,
 /// and — for non-polymer atoms — their residue name. Bond-graph merging on
 /// top of this predicate is handled by [`SubchainPartition::from_molecule`].
+///
+/// Biopolymer atoms (protein or nucleic, by classification flags) on the
+/// same chain are always kept together regardless of the raw `hetatm`
+/// record bit: a modified residue that's chemically part of a polymer
+/// strand but recorded as `HETATM` (e.g. a modified nucleotide) must not
+/// split the strand into separate subchains just because of how the
+/// source file recorded that one residue.
 #[inline]
 pub fn atoms_same_subchain(a: &Atom, b: &Atom) -> bool {
-    a.residue.chain == b.residue.chain
-        && a.state.hetatm == b.state.hetatm
-        && (!a.state.hetatm || a.residue.resn == b.residue.resn)
+    if a.residue.chain != b.residue.chain {
+        return false;
+    }
+    if a.state.flags.is_biomolecule() && b.state.flags.is_biomolecule() {
+        return true;
+    }
+    a.state.hetatm == b.state.hetatm && (!a.state.hetatm || a.residue.resn == b.residue.resn)
 }
 
 // ============================================================================
@@ -1562,5 +1573,101 @@ mod tests {
         // Add a bond — invalidation should kick in via add_bond.
         link(&mut mol, a[1], b[0]);
         assert_eq!(mol.subchain_partition().entries().len(), 1);
+    }
+
+    #[test]
+    fn polymer_subchains_not_broken_by_interior_hetatm_nucleotide() {
+        // DA-DC-<modified nucleotide, NUCLEIC-flagged but recorded as
+        // HETATM>-DG-DT: a modified base (e.g. a methylated/oxidized
+        // cytosine) chemically part of the strand, but recorded with the
+        // HETATM record type as depositors commonly do. The cartoon path's
+        // polymer_subchains() must see this as ONE 5-residue biopolymer
+        // subchain, not three pieces split around the interior residue.
+        let mut mol = ObjectMolecule::new("modified-nucleotide-chain");
+        add_residue_atoms(
+            &mut mol,
+            "Z",
+            "DA",
+            1,
+            &["P", "C1'"],
+            AtomFlags::NUCLEIC | AtomFlags::POLYMER,
+            false,
+        );
+        add_residue_atoms(
+            &mut mol,
+            "Z",
+            "DC",
+            2,
+            &["P", "C1'"],
+            AtomFlags::NUCLEIC | AtomFlags::POLYMER,
+            false,
+        );
+        add_residue_atoms(
+            &mut mol,
+            "Z",
+            "5CM",
+            3,
+            &["P", "C1'"],
+            AtomFlags::NUCLEIC | AtomFlags::POLYMER,
+            true,
+        );
+        add_residue_atoms(
+            &mut mol,
+            "Z",
+            "DG",
+            4,
+            &["P", "C1'"],
+            AtomFlags::NUCLEIC | AtomFlags::POLYMER,
+            false,
+        );
+        add_residue_atoms(
+            &mut mol,
+            "Z",
+            "DT",
+            5,
+            &["P", "C1'"],
+            AtomFlags::NUCLEIC | AtomFlags::POLYMER,
+            false,
+        );
+
+        let chain = mol.chains().next().expect("one chain");
+        let subchains: Vec<_> = chain.polymer_subchains().collect();
+        assert_eq!(
+            subchains.len(),
+            1,
+            "expected one contiguous polymer subchain, got {}",
+            subchains.len()
+        );
+        assert_eq!(subchains[0].len(), 10, "5 residues x 2 atoms each");
+    }
+
+    #[test]
+    fn partition_does_not_absorb_polymer_still_holds_with_new_predicate() {
+        // Guard against a regression where the biopolymer fast-path in
+        // atoms_same_subchain accidentally widens to non-biopolymer atoms:
+        // an ORGANIC-flagged HET residue adjacent to a biopolymer residue on
+        // the same chain must still split into separate subchains.
+        let mut mol = ObjectMolecule::new("asn-nag-still-splits");
+        add_residue_atoms(
+            &mut mol,
+            "A",
+            "ASN",
+            1,
+            &["N", "CA", "C", "O", "ND2"],
+            AtomFlags::PROTEIN | AtomFlags::POLYMER,
+            false,
+        );
+        add_residue_atoms(
+            &mut mol,
+            "A",
+            "NAG",
+            2,
+            &["C1", "C2"],
+            AtomFlags::ORGANIC,
+            true,
+        );
+        let chain = mol.chains().next().expect("one chain");
+        let subchains: Vec<_> = chain.subchains().collect();
+        assert_eq!(subchains.len(), 2);
     }
 }


### PR DESCRIPTION
## Summary

`atoms_same_subchain()` (`crates/patinae-mol/src/subchain.rs:574-578`) -- the predicate `ChainView::polymer_subchains()` uses for chain-scoped iteration (cartoon/ribbon backbone extraction) -- splits purely on the raw PDB/mmCIF `ATOM`/`HETATM` record-type bit:

```rust
pub fn atoms_same_subchain(a: &Atom, b: &Atom) -> bool {
    a.residue.chain == b.residue.chain
        && a.state.hetatm == b.state.hetatm
        && (!a.state.hetatm || a.residue.resn == b.residue.resn)
}
```

A residue that's chemically part of a protein/nucleic-acid strand but recorded as `HETATM` -- e.g. a modified nucleotide (5-methylcytosine, 5-hydroxymethylcytosine, etc., all common in real depositions) sitting *inside* an otherwise-contiguous chain -- breaks that chain into separate subchains around it, even though `SubchainKind::from_atom()` (`subchain.rs:53-68`) would classify all three pieces as `Biopolymer` (it checks `flags.is_biomolecule()` -- `PROTEIN`/`NUCLEIC` -- before the hetatm bit). Each spurious split forces an extra `SEG_START`/`SEG_END` pair in `extract_retained_backbone` (`backbone.rs:96-137`), producing a visible cartoon ribbon break at that residue with no real chain-topology reason.

Confirmed this against PDB 8C58 (a CpG methyltransferase crystallized with dsDNA containing 5-hydroxycytosine and 5-methylcytosine, both recorded as `HETATM` mid-strand) -- exactly the scenario this fixes.

## Fix

Same-chain atoms that are both biopolymer by classification (`PROTEIN` or `NUCLEIC` flags) now stay in one subchain regardless of the raw hetatm bit; non-biopolymer atoms keep the existing strict same-hetatm-and-resn behavior:

```rust
pub fn atoms_same_subchain(a: &Atom, b: &Atom) -> bool {
    if a.residue.chain != b.residue.chain {
        return false;
    }
    if a.state.flags.is_biomolecule() && b.state.flags.is_biomolecule() {
        return true;
    }
    a.state.hetatm == b.state.hetatm && (!a.state.hetatm || a.residue.resn == b.residue.resn)
}
```

Verified this doesn't regress the bond-aware Objects-panel path (`build_partition_with_bonds`, same file): its union-find already explicitly skips merging when either atom `is_biomolecule()` (`subchain.rs:739`), so a biopolymer run staying whole at the raw-run pass doesn't change Objects-panel grouping for HET components. Also re-checked the existing `partition_does_not_absorb_polymer` test (ASN-NAG glycosidic bond): NAG carries `ORGANIC` not `PROTEIN|NUCLEIC` flags, so the new branch doesn't trigger and that invariant still holds.

## Testing

- New unit test: a 5-residue chain `DA-DC-<modified residue, NUCLEIC-flagged but hetatm=true>-DG-DT`, asserting `ChainView::polymer_subchains()` now yields one 5-residue subchain (previously three).
- New regression-guard test confirming an `ORGANIC`-flagged HET residue adjacent to a biopolymer residue still splits into separate subchains (guards against the fast-path accidentally widening).
- `cargo test -p patinae-mol -p patinae-render`: 202 passed, 0 failed (200 existing + 2 new), full existing suite unchanged.
- `cargo fmt --check` / `cargo clippy --no-deps`: clean.