### PR TITLE
fix: keep dragging in sync when the mouse is released off-canvas

### DIFF
--- a/python/patinae/widget/_frontend.js
+++ b/python/patinae/widget/_frontend.js
@@ -16,6 +16,23 @@ function modBits(e) {
 
 const CLICK_THRESHOLD_SQ = 25;
 
+/** `MouseEvent.button` indices we forward to the renderer: left, middle, right. */
+const MOUSE_BUTTONS = [0, 1, 2];
+
+/** `MouseEvent.buttons` bit corresponding to a `MouseEvent.button` index. */
+function buttonBit(button) {
+  switch (button) {
+    case 0:
+      return 1; // left
+    case 1:
+      return 4; // middle
+    case 2:
+      return 2; // right
+    default:
+      return 0; // back/forward and friends are not forwarded
+  }
+}
+
 function decodeBase64(b64) {
   const bin = atob(b64);
   const bytes = new Uint8Array(bin.length);
@@ -112,20 +129,55 @@ export default {
     // ── Mouse events ───────────────────────────────────────────────
     let clickStart = null;
     let currentDpr = window.devicePixelRatio || 1;
+    // `MouseEvent.buttons` bitmask the WASM side currently believes is pressed.
+    let buttonMask = 0;
 
-    canvas.addEventListener("mousedown", (e) => {
+    // Release any button the renderer still holds but that `e.buttons` says is
+    // no longer pressed. Pointer capture covers the common "released outside
+    // the canvas" case, but capture can be denied or dropped (another element
+    // captured first, OS-level focus loss); without this the renderer keeps the
+    // button latched and the camera stays stuck in a drag.
+    const reconcileButtons = (e) => {
+      for (const button of MOUSE_BUTTONS) {
+        const bit = buttonBit(button);
+        if (!(buttonMask & bit) || e.buttons & bit) continue;
+        buttonMask &= ~bit;
+        wasm.on_mouse_up(e.offsetX, e.offsetY, button);
+        if (button === 0) clickStart = null;
+      }
+    };
+
+    canvas.addEventListener("pointerdown", (e) => {
       e.preventDefault();
       canvas.focus();
+      // Capture the pointer so a drag that leaves the canvas keeps delivering
+      // move/up events here instead of being swallowed by the document.
+      try {
+        canvas.setPointerCapture(e.pointerId);
+      } catch {
+        // Capture is best-effort; reconcileButtons() is the fallback.
+      }
+      reconcileButtons(e);
+      buttonMask |= buttonBit(e.button);
       wasm.on_mouse_down(e.offsetX, e.offsetY, e.button, modBits(e));
       if (e.button === 0) clickStart = { x: e.offsetX, y: e.offsetY };
     });
 
-    canvas.addEventListener("mousemove", (e) => {
+    canvas.addEventListener("pointermove", (e) => {
+      reconcileButtons(e);
       wasm.on_mouse_move(e.offsetX, e.offsetY, modBits(e));
       wasm.process_hover(e.offsetX * currentDpr, e.offsetY * currentDpr);
     });
 
-    canvas.addEventListener("mouseup", (e) => {
+    // Re-entering the canvas is the first chance to notice a button that was
+    // released while the cursor was elsewhere.
+    canvas.addEventListener("pointerenter", (e) => reconcileButtons(e));
+
+    canvas.addEventListener("pointerup", (e) => {
+      if (canvas.hasPointerCapture(e.pointerId)) {
+        canvas.releasePointerCapture(e.pointerId);
+      }
+      buttonMask &= ~buttonBit(e.button);
       wasm.on_mouse_up(e.offsetX, e.offsetY, e.button);
       if (e.button === 0 && clickStart) {
         const dx = e.offsetX - clickStart.x;
@@ -135,6 +187,22 @@ export default {
         }
         clickStart = null;
       }
+    });
+
+    // The browser took the pointer away (touch gesture, OS-level drag, ...):
+    // no pointerup is coming, so release everything we still hold.
+    canvas.addEventListener("pointercancel", (e) => {
+      if (canvas.hasPointerCapture(e.pointerId)) {
+        canvas.releasePointerCapture(e.pointerId);
+      }
+      for (const button of MOUSE_BUTTONS) {
+        if (buttonMask & buttonBit(button)) {
+          wasm.on_mouse_up(e.offsetX, e.offsetY, button);
+        }
+      }
+      buttonMask = 0;
+      clickStart = null;
+      wasm.process_hover(-1, -1);
     });
 
     canvas.addEventListener("mouseleave", () => {

--- a/web/ts/src/core/viewer.ts
+++ b/web/ts/src/core/viewer.ts
@@ -34,6 +34,8 @@ type WebViewerWithMemoryWarnings = WebViewer & {
 
 /** Click-detection threshold: drag distance squared in CSS pixels. */
 const CLICK_THRESHOLD_SQ = 25; // 5 CSS-px radius
+/** `MouseEvent.button` indices we forward to the renderer. */
+const MOUSE_BUTTONS = [0, 1, 2] as const; // left, middle, right
 const PERF_RING_CAPACITY = 240;
 
 export class ViewerCore {
@@ -45,6 +47,8 @@ export class ViewerCore {
   private _deferred = false;
   private _revealDuration = 150;
   private dpr = 1;
+  /** `MouseEvent.buttons` bitmask the WASM side currently believes is pressed. */
+  private buttonMask = 0;
   private clickStart: { x: number; y: number } | null = null;
   private fatalError: unknown | null = null;
   private fatalLabel: string | null = null;
@@ -365,13 +369,44 @@ export class ViewerCore {
   // Event binding
   // ---------------------------------------------------------------------------
 
+  /**
+   * Release any button the renderer still believes is pressed but that the
+   * event's `buttons` bitmask says is not.
+   *
+   * Pointer capture covers the common "released outside the canvas" case, but
+   * capture can be denied or silently dropped (another element captured first,
+   * OS-level focus loss, a native drag starting). Without this reconciliation
+   * the renderer keeps the button latched and the camera stays stuck in a drag
+   * on the next mouse move.
+   */
+  private reconcileButtons(e: PointerEvent): void {
+    for (const button of MOUSE_BUTTONS) {
+      const bit = buttonBit(button);
+      if (!(this.buttonMask & bit) || e.buttons & bit) continue;
+      this.buttonMask &= ~bit;
+      this.callWasm("on_mouse_up", (wasm) =>
+        wasm.on_mouse_up(e.offsetX, e.offsetY, button),
+      );
+      if (button === 0) this.clickStart = null;
+    }
+  }
+
   private bindEvents(): void {
     const c = this.canvas;
     this.dpr = window.devicePixelRatio || 1;
 
-    c.addEventListener("mousedown", (e) => {
+    c.addEventListener("pointerdown", (e) => {
       e.preventDefault();
       c.focus();
+      // Capture the pointer so a drag that leaves the canvas keeps delivering
+      // move/up events here instead of being swallowed by the document.
+      try {
+        c.setPointerCapture(e.pointerId);
+      } catch {
+        // Capture is best-effort; reconcileButtons() is the fallback.
+      }
+      this.reconcileButtons(e);
+      this.buttonMask |= buttonBit(e.button);
       this.callWasm("on_mouse_down", (wasm) =>
         wasm.on_mouse_down(e.offsetX, e.offsetY, e.button, modBits(e)),
       );
@@ -382,7 +417,8 @@ export class ViewerCore {
       }
     });
 
-    c.addEventListener("mousemove", (e) => {
+    c.addEventListener("pointermove", (e) => {
+      this.reconcileButtons(e);
       this.callWasm("on_mouse_move", (wasm) =>
         wasm.on_mouse_move(e.offsetX, e.offsetY, modBits(e)),
       );
@@ -393,7 +429,15 @@ export class ViewerCore {
       };
     });
 
-    c.addEventListener("mouseup", (e) => {
+    // Re-entering the canvas is the first chance to notice a button that was
+    // released while the cursor was elsewhere.
+    c.addEventListener("pointerenter", (e) => this.reconcileButtons(e));
+
+    c.addEventListener("pointerup", (e) => {
+      if (c.hasPointerCapture(e.pointerId)) {
+        c.releasePointerCapture(e.pointerId);
+      }
+      this.buttonMask &= ~buttonBit(e.button);
       this.callWasm("on_mouse_up", (wasm) =>
         wasm.on_mouse_up(e.offsetX, e.offsetY, e.button),
       );
@@ -410,6 +454,23 @@ export class ViewerCore {
         }
         this.clickStart = null;
       }
+    });
+
+    // The browser took the pointer away (touch gesture, OS-level drag, ...):
+    // no pointerup is coming, so release everything we still hold.
+    c.addEventListener("pointercancel", (e) => {
+      if (c.hasPointerCapture(e.pointerId)) {
+        c.releasePointerCapture(e.pointerId);
+      }
+      for (const button of MOUSE_BUTTONS) {
+        if (!(this.buttonMask & buttonBit(button))) continue;
+        this.callWasm("on_mouse_up", (wasm) =>
+          wasm.on_mouse_up(e.offsetX, e.offsetY, button),
+        );
+      }
+      this.buttonMask = 0;
+      this.clickStart = null;
+      this.queuedHover = { x: -1, y: -1 };
     });
 
     c.addEventListener("mouseleave", () => {
@@ -446,6 +507,20 @@ export class ViewerCore {
     const rect = this.canvas.getBoundingClientRect();
     this.canvas.width = Math.round(rect.width * dpr);
     this.canvas.height = Math.round(rect.height * dpr);
+  }
+}
+
+/** `MouseEvent.buttons` bit corresponding to a `MouseEvent.button` index. */
+function buttonBit(button: number): number {
+  switch (button) {
+    case 0:
+      return 1; // left
+    case 1:
+      return 4; // middle
+    case 2:
+      return 2; // right
+    default:
+      return 0; // back/forward and friends are not forwarded
   }
 }
 

--- a/web/ts/src/core/viewer.ts
+++ b/web/ts/src/core/viewer.ts
@@ -35,7 +35,7 @@ type WebViewerWithMemoryWarnings = WebViewer & {
 /** Click-detection threshold: drag distance squared in CSS pixels. */
 const CLICK_THRESHOLD_SQ = 25; // 5 CSS-px radius
 /** `MouseEvent.button` indices we forward to the renderer. */
-const MOUSE_BUTTONS = [0, 1, 2] as const; // left, middle, right
+const MOUSE_BUTTONS = [0, 1, 2, 3, 4] as const; // left, middle, right, back, forward
 const PERF_RING_CAPACITY = 240;
 
 export class ViewerCore {


### PR DESCRIPTION
## Problem

Both browser frontends bind camera input with `mousedown` / `mousemove` / `mouseup` on the canvas element. Those events only fire while the cursor is over the canvas, so a drag that is *released outside* the canvas never delivers `mouseup`.

The renderer's `InputState` therefore keeps the button in `ButtonState::Pressed`. Moving the cursor back over the canvas afterwards — with no button held — keeps rotating/panning the scene until the user clicks again to clear it.

This is easy to hit with a small embedded viewer: any rotation drag that overshoots the canvas edge leaves the camera stuck.

## Fix

- Switch the canvas handlers to **pointer events** and call `setPointerCapture()` on `pointerdown`, so a drag that leaves the canvas still delivers `pointermove` / `pointerup` to the canvas.
- Capture is best-effort — it can be denied or silently dropped (another element captured first, OS-level focus loss, a native drag starting). So the tracked button mask is also **reconciled against `PointerEvent.buttons`** on every `pointermove` and `pointerenter`, synthesizing the missing `on_mouse_up` for any button the renderer still holds.
- `pointercancel` releases every held button and clears hover state, since no `pointerup` follows it.

`mouseleave`, `wheel`, `contextmenu` and the `ResizeObserver` are unchanged. No public API changes.

The same defect existed in `python/patinae/widget/_frontend.js`, which is a separate hand-written implementation of the same wiring, so it gets the same treatment in the second commit.

## Files

- `web/ts/src/core/viewer.ts` — `ViewerCore.bindEvents()`, new private `reconcileButtons()` / `buttonMask`, module-level `buttonBit()` helper
- `python/patinae/widget/_frontend.js` — same change in the anywidget frontend

## Test plan

Automated / build:

- [x] `cd web && npm install && npm run build` — wasm-pack + vite build succeeds
- [x] `cd web && npx tsc --noEmit` — clean
- [x] `node --check python/patinae/widget/_frontend.js` — clean
- [x] Built `dist/patinae-viewer.js` verified to register `pointerdown` / `pointermove` / `pointerenter` / `pointerup` / `pointercancel`, with `mouseleave` and `contextmenu` retained

Not yet verified — would appreciate a check by anyone with the setup at hand:

- [ ] Manual browser check: left-drag rotate released outside the canvas no longer leaves the camera stuck; click-to-pick and the short-drag threshold still behave
- [ ] Middle/right-button drag (pan/zoom) across the canvas edge
- [ ] Touch and pen input
- [ ] The Jupyter widget path (`python/patinae/widget/_frontend.js`)

An equivalent change (same pointer-capture + reconciliation logic, applied to a built `patinae-viewer.js`) has been running in an embedded-viewer setup, which is what surfaced the bug; the sources here have not themselves been exercised in a browser yet.