### PR TITLE
feat: track pk1-4 pick slots on ctrl-click atom selection

### DIFF
--- a/crates/patinae-scene/src/selection.rs
+++ b/crates/patinae-scene/src/selection.rs
@@ -98,6 +98,48 @@ impl SelectionManager {
         self.generation += 1;
     }
 
+    /// Append an atom expression to PyMOL-compatible ordered pick slots.
+    pub fn push_pick(&mut self, expression: &str) {
+        if let Some(existing) = (1..=4).find(|index| {
+            self.get_expression(&format!("pk{index}"))
+                .is_some_and(|current| current == expression)
+        }) {
+            self.remove_pick_slot(existing);
+            return;
+        }
+
+        let slot = (1..=4)
+            .find(|index| !self.contains(&format!("pk{index}")))
+            .unwrap_or(4);
+        if slot == 4 && self.contains("pk4") {
+            for index in 1..4 {
+                if let Some(next) = self.get_expression(&format!("pk{}", index + 1)) {
+                    let next = next.to_string();
+                    self.define(&format!("pk{index}"), &next);
+                }
+            }
+        }
+        self.define(&format!("pk{slot}"), expression);
+    }
+
+    fn remove_pick_slot(&mut self, slot: usize) {
+        for index in slot..4 {
+            let next_name = format!("pk{}", index + 1);
+            if let Some(next) = self.get_expression(&next_name).map(str::to_owned) {
+                self.define(&format!("pk{index}"), &next);
+            } else {
+                self.remove(&format!("pk{index}"));
+            }
+        }
+        self.remove("pk4");
+    }
+
+    pub fn clear_picks(&mut self) {
+        for index in 1..=4 {
+            self.remove(&format!("pk{index}"));
+        }
+    }
+
     /// Define a named selection with pre-computed evaluation results.
     ///
     /// The `results` contain per-object SelectionResult bitvecs evaluated at
@@ -456,6 +498,47 @@ mod tests {
 
         manager.set_visible("sel1", true);
         assert!(manager.is_visible("sel1"));
+    }
+
+    #[test]
+    fn repeated_pick_toggles_the_same_atom_off() {
+        let mut manager = SelectionManager::new();
+        manager.push_pick("model 1crn and index 0");
+        assert_eq!(
+            manager.get_expression("pk1"),
+            Some("model 1crn and index 0")
+        );
+
+        manager.push_pick("model 1crn and index 0");
+        assert!(!manager.contains("pk1"));
+    }
+
+    #[test]
+    fn removing_a_pick_compacts_later_slots() {
+        let mut manager = SelectionManager::new();
+        manager.push_pick("index 1");
+        manager.push_pick("index 2");
+        manager.push_pick("index 3");
+
+        manager.push_pick("index 2");
+
+        assert_eq!(manager.get_expression("pk1"), Some("index 1"));
+        assert_eq!(manager.get_expression("pk2"), Some("index 3"));
+        assert!(!manager.contains("pk3"));
+    }
+
+    #[test]
+    fn clear_picks_removes_all_ordered_pick_slots() {
+        let mut manager = SelectionManager::new();
+        for index in 1..=4 {
+            manager.push_pick(&format!("index {index}"));
+        }
+
+        manager.clear_picks();
+
+        for index in 1..=4 {
+            assert!(!manager.contains(&format!("pk{index}")));
+        }
     }
 
     #[test]

--- a/patinae/src/app.rs
+++ b/patinae/src/app.rs
@@ -1110,20 +1110,39 @@ impl App {
         let hit = self.renderer.as_mut().and_then(|r| {
             r.pick_at_click(&self.kernel.session, click_pos.0 as u32, click_pos.1 as u32)
         });
+        let (_shift, ctrl, _alt, _logo) = self.winit_modifiers.get();
+        let hit_pickable_atom = hit.as_ref().is_some_and(|hit| {
+            hit.atom_index.is_some()
+                && self
+                    .kernel
+                    .session
+                    .registry
+                    .get_molecule(&hit.object_name)
+                    .is_some()
+        });
+        if ctrl && !hit_pickable_atom {
+            self.kernel.session.selections.clear_picks();
+        }
 
         let cmd = if let Some(ref hit) = hit {
             if let Some(mol_obj) = self.kernel.session.registry.get_molecule(&hit.object_name) {
                 let mol = mol_obj.molecule();
                 let mode = self.kernel.session.settings.ui.mouse_selection_mode as i32;
 
-                pick_expression_for_hit(hit, mode, mol).and_then(|expr| {
+                // Ordered measurement picks are always individual atoms,
+                // independent of the normal mouse selection expansion mode.
+                let expression_mode = if ctrl { 0 } else { mode };
+                pick_expression_for_hit(hit, expression_mode, mol).and_then(|expr| {
+                    if ctrl {
+                        self.kernel.session.selections.push_pick(&expr);
+                    }
                     let overlaps_sele =
                         self.kernel
                             .session
                             .selections
                             .get("sele")
                             .is_some_and(|entry| {
-                                let sel = expand_pick_to_selection(hit, mode, mol);
+                                let sel = expand_pick_to_selection(hit, expression_mode, mol);
                                 patinae_select::select(mol, &entry.expression)
                                     .map(|sele| sel.intersection(&sele).any())
                                     .unwrap_or(false)


### PR DESCRIPTION
## Summary
- Ctrl+click on a pickable atom now registers it into PyMOL-compatible ordered pick slots (`pk1`..`pk4`) via `SelectionManager::push_pick`
- Repeating a pick on the same atom toggles it off and compacts the remaining slots (matching PyMOL's `pk1`/`pk2`/`pk3`/`pk4` behavior)
- Ctrl+click that misses a pickable atom clears all pick slots via `clear_picks`
- Ordered picks always resolve to individual atoms, independent of the normal mouse selection expansion mode

## Test plan
- [x] `cargo test -p patinae-scene` (new `push_pick`/`clear_picks` unit tests)
- [x] `cargo build --workspace`
- [ ] Manual: ctrl-click 2/3/4 atoms in the viewport and confirm `pk1`..`pk4` are set/cleared as expected (used together with the `distance`/`angle`/`dihedral` commands from #measurement-label-rendering PR)